### PR TITLE
Add Jest tests for ingredient hashing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'package.json'
+      - '.github/workflows/test.yml'
+      - '!data/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cookbook",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0"
+  }
+}

--- a/scripts/__tests__/check-duplicates.test.js
+++ b/scripts/__tests__/check-duplicates.test.js
@@ -1,0 +1,23 @@
+const { hashIngredients } = require('../check-duplicates');
+
+describe('hashIngredients', () => {
+  test('is case-insensitive', () => {
+    const a = [
+      { items: [{ item: 'Sugar' }, { item: 'flour' }] }
+    ];
+    const b = [
+      { items: [{ item: 'sugar' }, { item: 'Flour' }] }
+    ];
+    expect(hashIngredients(a)).toBe(hashIngredients(b));
+  });
+
+  test('order differences yield same hash', () => {
+    const a = [
+      { items: [{ item: 'milk' }, { item: 'eggs' }] }
+    ];
+    const b = [
+      { items: [{ item: 'eggs' }, { item: 'milk' }] }
+    ];
+    expect(hashIngredients(a)).toBe(hashIngredients(b));
+  });
+});


### PR DESCRIPTION
## Summary
- make `hashIngredients` exportable and avoid running duplicate check when imported
- write Jest tests for ingredient hashing normalization and ordering
- ignore `node_modules`
- add package.json with Jest
- add CI workflow to run tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0539b810832b803040f55929c347